### PR TITLE
Add Latin translation

### DIFF
--- a/src/main/resources/assets/ratsmischief/lang/la_la.json
+++ b/src/main/resources/assets/ratsmischief/lang/la_la.json
@@ -14,7 +14,7 @@
   "type.ratsmischief.albino": "Albus",
   "type.ratsmischief.black": "Ater",
   "type.ratsmischief.grey": "Cinereus",
-  "type.ratsmischief.husky": "Husci",
+  "type.ratsmischief.husky": "Husky",
   "type.ratsmischief.chocolate": "Socolatae",
   "type.ratsmischief.light_brown": "Cervinus",
   "type.ratsmischief.russian_blue": "Caeruleus-Russicus",


### PR DESCRIPTION
I'm sure lots of people will use this /s

Translation notes:
 - 'twisted' (in 'twisted rat pouch') expanded in translation to 'venearum contortarum' ('of twisted vines')
 - 'Purpurei' capitalised for consistency with Minecraft's Latin translations (in which 'Purpureus' refers to Purpur and 'purpureus' is the adjective 'purple')
 - 'skirmish staff' translated as 'Virga pugnandi' ('staff of fighting')
 - 'Elytrat' translated as 'Elytrattus' to preserve the pun
 - 'grey' translated as 'Cinereus' ('ashen')
 - 'chocolate' translated as 'Socolatae' ('of chocolate', New Latin)
 - 'light brown' translated as 'Cervinus' ('tawny')
 - ~~'Husky' transliterated to 'Husci' because it fits in more, considering changing it back though.~~ changed back to 'Husky'